### PR TITLE
Initialize NuGet's Credential Service

### DIFF
--- a/NuKeeper/Local/LocalEngine.cs
+++ b/NuKeeper/Local/LocalEngine.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using NuGet.Credentials;
 using NuKeeper.Abstractions.Configuration;
 using NuKeeper.Abstractions.Inspections.Files;
 using NuKeeper.Abstractions.Logging;
@@ -43,6 +44,8 @@ namespace NuKeeper.Local
 
         public async Task Run(SettingsContainer settings, bool write)
         {
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(new NuGet.Common.NullLogger(), true);
+
             var folder = TargetFolder(settings.UserSettings);
 
             var sources = _nuGetSourcesReader.Read(folder, settings.UserSettings.NuGetSources);

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -15,6 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="NuGet.Credentials" Version="5.2.0" />
     <PackageReference Include="SimpleInjector" Version="4.6.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Initialize NuGet's credential provider service to be able to use private Azure Artifacts feeds via Microsoft's Azure Artifacts credential provider.