### PR TITLE
Make the package-has-no-version log a more verbose log level message …

### DIFF
--- a/NuKeeper.Inspection/RepositoryInspection/PackageInProjectReader.cs
+++ b/NuKeeper.Inspection/RepositoryInspection/PackageInProjectReader.cs
@@ -27,7 +27,8 @@ namespace NuKeeper.Inspection.RepositoryInspection
 
             if (string.IsNullOrWhiteSpace(version))
             {
-                _logger.Normal($"Skipping package '{id}' with no version specified in file '{path.FullName}'.");
+                // TODO this is very spammy when using MSBuild Directory.build.props or .targets files for versioning NuGets. Should find a better way for this.
+                _logger.Detailed($"Skipping package '{id}' with no version specified in file '{path.FullName}'.");
                 return null;
             }
 


### PR DESCRIPTION
…to avoid directory.build files spammy for now